### PR TITLE
[SUS-120] - Deletion of objects with UTF-8 using four-byte encodings is not supported in console, but working fine with cli

### DIFF
--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -2927,7 +2927,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function XmlBuilder() { }
 
 	XmlBuilder.prototype.toXML = function(params, shape, rootElement, noEmpty) {
-	  var xml = builder.create(rootElement);
+	  var xml = builder.create(rootElement, { allowSurrogateChars: true });
 	  applyNamespaces(xml, shape);
 	  serialize(xml, params, shape);
 	  return xml.children.length > 0 || noEmpty ? xml.root().toString() : '';

--- a/dist/aws-sdk-react-native.js
+++ b/dist/aws-sdk-react-native.js
@@ -3229,7 +3229,7 @@ return /******/ (function(modules) { // webpackBootstrap
 		function XmlBuilder() { }
 
 		XmlBuilder.prototype.toXML = function(params, shape, rootElement, noEmpty) {
-		  var xml = builder.create(rootElement);
+		  var xml = builder.create(rootElement, { allowSurrogateChars: true });
 		  applyNamespaces(xml, shape);
 		  serialize(xml, params, shape);
 		  return xml.children.length > 0 || noEmpty ? xml.root().toString() : '';

--- a/dist/aws-sdk.js
+++ b/dist/aws-sdk.js
@@ -133868,7 +133868,7 @@ var builder = require('xmlbuilder');
 function XmlBuilder() { }
 
 XmlBuilder.prototype.toXML = function(params, shape, rootElement, noEmpty) {
-  var xml = builder.create(rootElement);
+  var xml = builder.create(rootElement, { allowSurrogateChars: true });
   applyNamespaces(xml, shape);
   serialize(xml, params, shape);
   return xml.children.length > 0 || noEmpty ? xml.root().toString() : '';

--- a/lib/xml/builder.js
+++ b/lib/xml/builder.js
@@ -4,7 +4,7 @@ var builder = require('xmlbuilder');
 function XmlBuilder() { }
 
 XmlBuilder.prototype.toXML = function(params, shape, rootElement, noEmpty) {
-  var xml = builder.create(rootElement);
+  var xml = builder.create(rootElement, { allowSurrogateChars: true });
   applyNamespaces(xml, shape);
   serialize(xml, params, shape);
   return xml.children.length > 0 || noEmpty ? xml.root().toString() : '';


### PR DESCRIPTION
## Description
This change was made now because with CRDB we now support UTF-8 four byte characters as keys for objects. We need the flag to not get the throw new Error("Invalid character (" + chr + ") in string: " + str + " at index " + chr.index); as seen in the ticket.

## where the feature flag is used in the library
node_modules/xmlbuilder/lib/XMLStringifier.js. (Generated by CoffeeScript 1.9.1)

... 

XMLStringifier.prototype.assertLegalChar = function(str) {
      var chars, chr;
      if (this.allowSurrogateChars) {
        chars = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uFFFE-\uFFFF]/;
      } else {
        chars = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/;
      }
      chr = str.match(chars);
      if (chr) {
        throw new Error("Invalid character (" + chr + ") in string: " + str + " at index " + chr.index);
      }
      return str;
    };

...

#Jira Ticket
https://wasabi.atlassian.net/browse/SUS-120


